### PR TITLE
feat(bintray): Add missing metadata for Bintray

### DIFF
--- a/gradle/bintrayv.gradle
+++ b/gradle/bintrayv.gradle
@@ -84,7 +84,10 @@ bintray {
         repo = 'maven'
         name = project.ext.CODENAME
         desc = project.ext.DESC
-        labels = project.ext.LABELS
+        labels = ['algolia', 'instantsearch', 'android', project.ext.BASENAME]
+        if (project.hasProperty("LABELS")) {
+            labels += project.ext.LABELS
+        }
         licenses = [project.ext.LICENSE]
         vcsUrl = project.ext.REPO
         websiteUrl = project.ext.WEBSITE

--- a/gradle/bintrayv.gradle
+++ b/gradle/bintrayv.gradle
@@ -90,7 +90,7 @@ bintray {
         }
         publicDownloadNumbers = false
         githubRepo = project.ext.GITHUB
-        githubReleaseNotesFile = project.hasProperty('README')? project.ext.README: "README.md"
+        githubReleaseNotesFile = project.hasProperty('CHANGELOG')? project.ext.CHANGELOG: "CHANGELOG.md"
 
         licenses = [project.ext.LICENSE]
         vcsUrl = project.ext.REPO

--- a/gradle/bintrayv.gradle
+++ b/gradle/bintrayv.gradle
@@ -88,15 +88,24 @@ bintray {
         if (project.hasProperty("LABELS")) {
             labels += project.ext.LABELS
         }
+        publicDownloadNumbers = false
+        githubRepo = project.ext.GITHUB
+        githubReleaseNotesFile = project.hasProperty('README')? project.ext.README: "README.md"
+
         licenses = [project.ext.LICENSE]
         vcsUrl = project.ext.REPO
         websiteUrl = project.ext.WEBSITE
-        issueTrackerUrl = project.ext.WEBSITE + '/issues/'
+        issueTrackerUrl = project.ext.WEBSITE + '/issues'
+        attributes = [
+                'maturity': "Stable",
+        ]
 
         publish = true
         version {
             name = project.ext.VERSION
             vcsTag = project.ext.VERSION
+            released = new Date()
+            desc = project.ext.VERSION_DESC
         }
     }
 }

--- a/gradle/bintrayv.gradle
+++ b/gradle/bintrayv.gradle
@@ -105,7 +105,7 @@ bintray {
             name = project.ext.VERSION
             vcsTag = project.ext.VERSION
             released = new Date()
-            desc = project.ext.VERSION_DESC
+            desc = project.hasProperty('VERSION_DESC')? project.ext.VERSION_DESC : "$project.ext.NAME - v$project.ext.VERSION"
         }
     }
 }


### PR DESCRIPTION
## Project attributes

_Note that these metadata are only set at the project creation. Deploying a new version won't update e.g. `Maturity`, `labels`, etc: only the `version {}` seem to have an impact for new versions._

- Adds labels: some defaults including `project.BASENAME` (`insights`, `voice`, `UI`, ...) + project defined labels if any
- Enforces download numbers hidden until set otherwise
- Adds GitHub repo/release notes
- Sets Maturity to `Stable` by default 
->**Question: would we rather set `Development` (implying unstable) at repo creation and manually set `Stable` or `Official` when confident?**

 
## Version attributes
- Release date (weirdly without this Bintray does not implicitly set the current date as release date)
- Description
